### PR TITLE
Add ForceNew option and modify for passing InternalValidate

### DIFF
--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -1,8 +1,6 @@
 package vsphere
 
 import (
-	"os"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -14,21 +12,21 @@ func Provider() terraform.ResourceProvider {
 			"user": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: envDefaultFunc("VSPHERE_USER"),
+				DefaultFunc: schema.EnvDefaultFunc("VSPHERE_USER", nil),
 				Description: "The user name for vSphere API operations.",
 			},
 
 			"password": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: envDefaultFunc("VSPHERE_PASSWORD"),
+				DefaultFunc: schema.EnvDefaultFunc("VSPHERE_PASSWORD", nil),
 				Description: "The user password for vSphere API operations.",
 			},
 
 			"vcenter_server": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: envDefaultFunc("VSPHERE_VCENTER"),
+				DefaultFunc: schema.EnvDefaultFunc("VSPHERE_VCENTER", nil),
 				Description: "The vCenter Server name for vSphere API operations.",
 			},
 		},
@@ -38,16 +36,6 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ConfigureFunc: providerConfigure,
-	}
-}
-
-func envDefaultFunc(k string) schema.SchemaDefaultFunc {
-	return func() (interface{}, error) {
-		if v := os.Getenv(k); v != "" {
-			return v, nil
-		}
-
-		return nil, nil
 	}
 }
 

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -17,69 +17,82 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceVSphereVirtualMachineCreate,
 		Read:   resourceVSphereVirtualMachineRead,
+		Update: resourceVSphereVirtualMachineUpdate,
 		Delete: resourceVSphereVirtualMachineDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"template": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: false,
 			},
 
 			"vcpu": &schema.Schema{
 				Type:     schema.TypeInt,
 				Required: true,
+				ForceNew: false,
 			},
 
 			"memory": &schema.Schema{
 				Type:     schema.TypeInt,
 				Required: true,
+				ForceNew: false,
 			},
 
 			"datacenter": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: false,
 			},
 
 			"cluster": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: false,
 			},
 
 			"resource_pool": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: false,
 			},
 
 			"datastore": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: false,
 			},
 
 			"gateway": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: false,
 			},
 
 			"domain": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: false,
 			},
 
 			"dns_suffix": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: false,
 			},
 
 			"dns_server": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: false,
 			},
 
 			"network_interface": &schema.Schema{
@@ -90,16 +103,19 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 						"label": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: false,
 						},
 
 						"ip_address": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: false,
 						},
 
 						"subnet_mask": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: false,
 						},
 					},
 				},
@@ -215,6 +231,10 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 	d.Set("memory", mvm.Summary.Config.MemorySizeMB)
 	d.Set("cpu", mvm.Summary.Config.NumCpu)
 
+	return nil
+}
+
+func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 


### PR DESCRIPTION
Fixes for InternalValidate error.

```
$ go test ./...
?       github.com/rakutentech/terraform-provider-vsphere   [no test files]
--- FAIL: TestProvider (0.00s)
    provider_test.go:23: err: vsphere_virtual_machine: No Update defined, must set ForceNew on: []string{"template", "memory", "cluster", "datastore", "dns_suffix", "network_interface", "vcpu", "datacenter", "resource_pool", "gateway", "domain", "dns_server"}
FAIL
FAIL    github.com/rakutentech/terraform-provider-vsphere/vsphere   0.025s
```
