### PR TITLE
Use finder.VirtualMachine func to support the feature that vm template in child folders can be specified.

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -220,13 +220,8 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	d.Set("datacenter", dc)
-	dcFolders, err := dc.Folders(context.TODO())
-	if err != nil {
-		return err
-	}
-
-	vm, err := getVirtualMachine(client, dcFolders.VmFolder, d.Get("name").(string))
+	finder = finder.SetDatacenter(dc)
+	vm, err := finder.VirtualMachine(context.TODO(), d.Get("name").(string))
 	if err != nil {
 		log.Printf("[ERROR] Virtual machine not found: %s", d.Get("name").(string))
 		d.SetId("")
@@ -238,6 +233,7 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 	collector := property.DefaultCollector(client.Client)
 	err = collector.RetrieveOne(context.TODO(), vm.Reference(), []string{"summary"}, &mvm)
 
+	d.Set("datacenter", dc)
 	d.Set("memory", mvm.Summary.Config.MemorySizeMB)
 	d.Set("cpu", mvm.Summary.Config.NumCpu)
 
@@ -259,13 +255,8 @@ func resourceVSphereVirtualMachineDelete(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	d.Set("datacenter", dc)
-	dcFolders, err := dc.Folders(context.TODO())
-	if err != nil {
-		return err
-	}
-
-	vm, err := getVirtualMachine(client, dcFolders.VmFolder, d.Get("name").(string))
+	finder = finder.SetDatacenter(dc)
+	vm, err := finder.VirtualMachine(context.TODO(), d.Get("name").(string))
 	if err != nil {
 		return err
 	}

--- a/vsphere/virtual_machine.go
+++ b/vsphere/virtual_machine.go
@@ -75,7 +75,7 @@ func (vm *VirtualMachine) deployVirtualMachine(c *govmomi.Client) error {
 	}
 
 	vmFolder := dcFolders.VmFolder
-	template, err := getVirtualMachine(c, vmFolder, vm.Template)
+	template, err := finder.VirtualMachine(context.TODO(), vm.Template)
 	if err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ func (vm *VirtualMachine) deployVirtualMachine(c *govmomi.Client) error {
 		return err
 	}
 
-	newVM, err := getVirtualMachine(c, vmFolder, vm.Name)
+	newVM, err := finder.VirtualMachine(context.TODO(), vm.Name)
 	if err != nil {
 		return err
 	}
@@ -321,17 +321,6 @@ func getDatacenter(f *find.Finder, name string) (*object.Datacenter, error) {
 		}
 		return dc, nil
 	}
-}
-
-// getVirtualMachine finds VirtualMachine or Template object
-func getVirtualMachine(c *govmomi.Client, f *object.Folder, name string) (*object.VirtualMachine, error) {
-	s := object.NewSearchIndex(c.Client)
-	vmRef, err := s.FindChild(context.TODO(), f, name)
-	if err != nil {
-		return nil, err
-	}
-	vm := object.NewVirtualMachine(c.Client, vmRef.Reference())
-	return vm, nil
 }
 
 // getResourcePool finds ResourcePool object


### PR DESCRIPTION
This fixes #4.

By this modification, this provider supports the feature that vm template in child folders can be specified.

e.g.)

```
resource "vsphere_virtual_machine" "default" {
    name = "secret_hostname"
    datacenter = "secret_datacenter"
    cluster = "secret_cluster"
    datastore = "secret_emc"
    template = "templates/linux-vm-template"
    vcpu = 2
    memory = 2048
    gateway = "10.1.1.1"
    network_interface {
        device_name = "eth1"
        label = "Private-VLAN-1"
        ip_address = "10.1.1.10"
        subnet_mask = "255.255.255.0"
    }
}
```
