### PR TITLE
fix networking wait for when datacenter is not given

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -460,7 +460,15 @@ func resourceVSphereVirtualMachineDelete(d *schema.ResourceData, meta interface{
 func waitForNetworkingActive(client *govmomi.Client, datacenter, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		finder := find.NewFinder(client.Client, true)
-		dc, err := finder.Datacenter(context.TODO(), datacenter)
+		var dc *object.Datacenter
+		var err error
+
+		if datacenter != "" {
+			dc, err = finder.Datacenter(context.TODO(), datacenter)
+		} else {
+			dc, err = finder.DefaultDatacenter(context.TODO())
+		}
+
 		if err != nil {
 			log.Printf("[ERROR] %#v", err)
 			return nil, "", err


### PR DESCRIPTION
When the datacenter isn't given as an attribute, it'll use the default datacenter. I found one place during the networking wait in which it was expecting it to be set, but it might not be.
