### PR TITLE
use the short hostname for custom spec

### DIFF
--- a/vsphere/virtual_machine.go
+++ b/vsphere/virtual_machine.go
@@ -3,6 +3,7 @@ package vsphere
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
@@ -334,7 +335,7 @@ func (vm *virtualMachine) deployVirtualMachine(c *govmomi.Client) error {
 	customSpec := types.CustomizationSpec{
 		Identity: &types.CustomizationLinuxPrep{
 			HostName: &types.CustomizationFixedName{
-				Name: vm.name,
+				Name: strings.Split(vm.name, ".")[0],
 			},
 			Domain:     vm.domain,
 			TimeZone:   vm.timeZone,


### PR DESCRIPTION
We've typically used the whole fqdn hostname as the name of the virtual machine. However, with the custom spec, it seems you cannot use the whole fqdn for the host part. I'm not really sure why, but https://communities.vmware.com/thread/309066 says a little bit.

Anyways, this is my my feeble attempt to fix that by making sure that the short hostname is used in the custom spec. 
